### PR TITLE
Add printCompactState and refactor serial output

### DIFF
--- a/GNC/ctrldRogallo.cpp
+++ b/GNC/ctrldRogallo.cpp
@@ -1,5 +1,6 @@
 #include "ctrldRogallo.h"
 #include <cmath>
+#include "EUSBSerial.h"
 #include "GPS.h"
 #include "BMP280.h"
 #include "BNO055.h"
@@ -357,6 +358,19 @@ uint32_t ctrldRogallo::groundedDetection(double prevAlt, double currAlt) {
 void ctrldRogallo::setThreshold(){
     groundedThreshold = state.altitude_m + GROUNDED_THRESHOLD_BUFFER;
     apogeeThreshold = state.altitude_m + APOGEE_THRESHOLD_BUFFER; 
+}
+
+void ctrldRogallo::printCompactState(EUSBSerial* pc) {
+    pc->printf("Lat (deg), Lon (deg), Alt (m):\t%f, %f, %.3f\n", 
+                state.latitude_deg, state.longitude_deg, state.altitude_m);
+    pc->printf("Pos North (m), Pos East (m):\t%.2f, %.2f\n", 
+                state.pos_north_m, state.pos_east_m);
+    pc->printf("Distance to Target:\t\t%.2f\n", state.distance_to_target_m);
+    pc->printf("FSM mode:\t\t\t%d\n", state.fsm_mode);
+    pc->printf("Apogee Counter:\t\t\t%d\n", state.apogee_counter);
+    pc->printf("Apogee Detected:\t\t%d\n", state.apogee_detected);
+    pc->printf("Grounded Counter:\t\t%d \n", state.groundedCounter);
+    pc->printf("==========================================================\n");
 }
 
 // string ctrldRogallo::getCompassDirection(float rollMag, float pitchMag){

--- a/GNC/ctrldRogallo.h
+++ b/GNC/ctrldRogallo.h
@@ -3,6 +3,7 @@
 #include "GPS.h"
 #include "BMP280.h"
 #include "BNO055.h"
+#include "EUSBSerial.h"
 #include "flash.h"
 #include "flight_packet.h"
 #include <cstdint>
@@ -43,7 +44,6 @@ class ctrldRogallo {
         void updateDistanceToTarget(void);
         void updateHaversineCoords(void);
         bool isWithinTarget(void);
-        
         void setModeFSM(ModeFSM mode);
         float getFuzedAlt(float alt1, float alt2);
         void setAlphaAlt(float newAlphaAlt);
@@ -65,6 +65,7 @@ class ctrldRogallo {
         void logData();
         void logDataTEST();
         const FlightPacket getState();
+        void printCompactState(EUSBSerial* pc);
 };
 
 


### PR DESCRIPTION
Introduced ctrldRogallo::printCompactState for concise state printing to serial. Updated main.cpp to use this new method, reducing code duplication. Also added ctrl_sequence_after_apogee function for post-apogee control logic (in-work).